### PR TITLE
Respect the python interpreter given by the 'python' attr.

### DIFF
--- a/pypi/tools/locate_archive.py
+++ b/pypi/tools/locate_archive.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import print_function
 from argparse import ArgumentParser
 import os.path

--- a/pypi/universal.bzl
+++ b/pypi/universal.bzl
@@ -9,7 +9,7 @@ def _universal_install_action(ctx, python, pip, pkg, version):
   envs = ["CC", "CXX", "CPP", "LD", "AS"]
   cmd = ["env"] + ["%s=/dev/null" % e for e in envs]
   result = ctx.execute(cmd + [
-      ctx.path(pip), "install",
+      python, ctx.path(pip), "install",
       "--isolated", "--no-deps",
       "--root=%s" % ctx.path(''),
       "--ignore-installed",


### PR DESCRIPTION
- Shebang not needed for locate_archive.py
- Prefix pip call with python argument from the attribute.
