### PR TITLE
Makes wheel installs inherit outer environment.

### DIFF
--- a/pypi/wheel.bzl
+++ b/pypi/wheel.bzl
@@ -37,6 +37,7 @@ def _wheel_impl(ctx):
           "CFLAGS": " ".join(copts),
           "LDFLAGS": " ".join(_linker_options(ctx)),
       },
+      use_default_shell_env = True,
   )
 
 pypi_internal_wheel = rule(


### PR DESCRIPTION
Some packages (psycopg2 for example) try to read things out of the PATH.

The output from trying to install a package that uses psycopg2:
```
INFO: Found 1 target...
ERROR: /home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/external/pypi_psycopg2/BUILD:9:1: error executing shell command: 'bazel-out/host/bin/external/python_pip_tools/pip wheel -w bazel-out/local-fastbuild/bin/external/pypi_psycopg2 external/pypi_psycopg2/psycopg2-2.5.5.tar.gz && mv bazel-out/local-fastbuild/bin/exter...' failed: linux-sandbox failed: error executing command /home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/execroot/pda/_bin/linux-sandbox ... (remaining 5 argument(s) skipped).
Processing ./external/pypi_psycopg2/psycopg2-2.5.5.tar.gz
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-CkfR5m-build/setup.py", line 583, in <module>
        ext_modules=ext)
      File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/bazel-sandbox/f5646444-cbb1-4b3d-89a7-2796af5640da-1/execroot/pda/bazel-out/host/bin/external/python_pip_tools/pip.runfiles/python_pip_tools/site-packages/setuptools/command/egg_info.py", line 195, in run
        self.find_sources()
      File "/home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/bazel-sandbox/f5646444-cbb1-4b3d-89a7-2796af5640da-1/execroot/pda/bazel-out/host/bin/external/python_pip_tools/pip.runfiles/python_pip_tools/site-packages/setuptools/command/egg_info.py", line 222, in find_sources
        mm.run()
      File "/home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/bazel-sandbox/f5646444-cbb1-4b3d-89a7-2796af5640da-1/execroot/pda/bazel-out/host/bin/external/python_pip_tools/pip.runfiles/python_pip_tools/site-packages/setuptools/command/egg_info.py", line 306, in run
        self.add_defaults()
      File "/home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/bazel-sandbox/f5646444-cbb1-4b3d-89a7-2796af5640da-1/execroot/pda/bazel-out/host/bin/external/python_pip_tools/pip.runfiles/python_pip_tools/site-packages/setuptools/command/egg_info.py", line 335, in add_defaults
        sdist.add_defaults(self)
      File "/home/robert/.cache/bazel/_bazel_robert/6b1e6b942b0f44b3f3c94c8bf1e0869c/bazel-sandbox/f5646444-cbb1-4b3d-89a7-2796af5640da-1/execroot/pda/bazel-out/host/bin/external/python_pip_tools/pip.runfiles/python_pip_tools/site-packages/setuptools/command/sdist.py", line 171, in add_defaults
        build_ext = self.get_finalized_command('build_ext')
      File "/usr/lib/python2.7/distutils/cmd.py", line 312, in get_finalized_command
        cmd_obj.ensure_finalized()
      File "/usr/lib/python2.7/distutils/cmd.py", line 109, in ensure_finalized
        self.finalize_options()
      File "/tmp/pip-CkfR5m-build/setup.py", line 379, in finalize_options
        pg_config_helper = PostgresConfig(self)
      File "/tmp/pip-CkfR5m-build/setup.py", line 100, in __init__
        self.pg_config_exe = self.autodetect_pg_config_path()
      File "/tmp/pip-CkfR5m-build/setup.py", line 148, in autodetect_pg_config_path
        return self.find_on_path('pg_config')
      File "/tmp/pip-CkfR5m-build/setup.py", line 136, in find_on_path
        path_directories = os.environ['PATH'].split(os.pathsep)
      File "/usr/lib/python2.7/UserDict.py", line 40, in __getitem__
        raise KeyError(key)
    KeyError: 'PATH'
    
    ----------------------------------------
The directory '/nonexistent/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-CkfR5m-build/
The directory '/nonexistent/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
You are using pip version 8.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```